### PR TITLE
fix(stop-segment)

### DIFF
--- a/muxer_segmenter_fmp4.go
+++ b/muxer_segmenter_fmp4.go
@@ -386,6 +386,7 @@ func (m *muxerSegmenterFMP4) writeVideo(
 		m.firstSegmentFinalized = true
 
 		if stoppingFrame {
+			m.nextVideoSample = nil
 			m.currentSegment = nil
 			return nil
 		}


### PR DESCRIPTION
## Changes

- [x] Fixed issue where extra segment would get created when it was not supposed to, causing the video playback to break