### PR TITLE
feat(segmenter-reset)

### DIFF
--- a/muxer.go
+++ b/muxer.go
@@ -204,6 +204,11 @@ func (m *Muxer) Close() {
 	m.segmenter.close()
 }
 
+func (m *Muxer) Reset() {
+	m.server.close()
+	m.segmenter.reset()
+}
+
 // WriteAV1 writes an AV1 temporal unit.
 func (m *Muxer) WriteAV1(ntp time.Time, pts time.Duration, tu [][]byte) error {
 	codec := m.VideoTrack.Codec.(*codecs.AV1)

--- a/muxer_segmenter.go
+++ b/muxer_segmenter.go
@@ -6,6 +6,7 @@ import (
 
 type muxerSegmenter interface {
 	close()
+	reset()
 	writeAV1(time.Time, time.Duration, [][]byte, bool, bool) error
 	writeVP9(time.Time, time.Duration, []byte, bool, bool) error
 	writeH26x(time.Time, time.Duration, [][]byte, bool, bool, bool) error

--- a/muxer_segmenter_fmp4.go
+++ b/muxer_segmenter_fmp4.go
@@ -174,9 +174,6 @@ func (m *muxerSegmenterFMP4) reset() {
 		m.currentSegment.finalize(0) //nolint:errcheck
 		m.currentSegment.close()
 	}
-	m.nextVideoSample = nil
-	m.firstSegmentFinalized = false
-	m.sampleDurations = make(map[time.Duration]struct{})
 }
 
 func (m *muxerSegmenterFMP4) genSegmentID() uint64 {

--- a/muxer_segmenter_fmp4.go
+++ b/muxer_segmenter_fmp4.go
@@ -174,6 +174,9 @@ func (m *muxerSegmenterFMP4) reset() {
 		m.currentSegment.finalize(0) //nolint:errcheck
 		m.currentSegment.close()
 	}
+	m.nextVideoSample = nil
+	m.firstSegmentFinalized = false
+	m.sampleDurations = make(map[time.Duration]struct{})
 }
 
 func (m *muxerSegmenterFMP4) genSegmentID() uint64 {

--- a/muxer_segmenter_mpegts.go
+++ b/muxer_segmenter_mpegts.go
@@ -91,7 +91,7 @@ func (m *muxerSegmenterMPEGTS) close() {
 	}
 }
 
-func (m *muxerSegmenterFMP4) reset() {
+func (m *muxerSegmenterMPEGTS) reset() {
 	if m.currentSegment != nil {
 		m.currentSegment.finalize(0) //nolint:errcheck
 		m.currentSegment.close()
@@ -100,7 +100,6 @@ func (m *muxerSegmenterFMP4) reset() {
 	m.firstSegmentFinalized = false
 	m.sampleDurations = make(map[time.Duration]struct{})
 }
-
 
 func (m *muxerSegmenterMPEGTS) genSegmentID() uint64 {
 	id := m.nextSegmentID

--- a/muxer_segmenter_mpegts.go
+++ b/muxer_segmenter_mpegts.go
@@ -91,6 +91,17 @@ func (m *muxerSegmenterMPEGTS) close() {
 	}
 }
 
+func (m *muxerSegmenterFMP4) reset() {
+	if m.currentSegment != nil {
+		m.currentSegment.finalize(0) //nolint:errcheck
+		m.currentSegment.close()
+	}
+	m.nextVideoSample = nil
+	m.firstSegmentFinalized = false
+	m.sampleDurations = make(map[time.Duration]struct{})
+}
+
+
 func (m *muxerSegmenterMPEGTS) genSegmentID() uint64 {
 	id := m.nextSegmentID
 	m.nextSegmentID++

--- a/muxer_segmenter_mpegts.go
+++ b/muxer_segmenter_mpegts.go
@@ -96,9 +96,6 @@ func (m *muxerSegmenterMPEGTS) reset() {
 		m.currentSegment.finalize(0) //nolint:errcheck
 		m.currentSegment.close()
 	}
-	m.nextVideoSample = nil
-	m.firstSegmentFinalized = false
-	m.sampleDurations = make(map[time.Duration]struct{})
 }
 
 func (m *muxerSegmenterMPEGTS) genSegmentID() uint64 {


### PR DESCRIPTION
## Changes

- [x] Added support so the segmenter can be reset (implementation is similar to `close()` but it resets a few more items)