### PR TITLE
fix(muxer-server-reset)

### DIFF
--- a/muxer.go
+++ b/muxer.go
@@ -205,7 +205,7 @@ func (m *Muxer) Close() {
 }
 
 func (m *Muxer) Reset() {
-	m.server.close()
+	m.server.reset()
 	m.segmenter.reset()
 }
 

--- a/muxer.go
+++ b/muxer.go
@@ -205,7 +205,6 @@ func (m *Muxer) Close() {
 }
 
 func (m *Muxer) Reset() {
-	m.server.reset()
 	m.segmenter.reset()
 }
 

--- a/muxer_server.go
+++ b/muxer_server.go
@@ -581,7 +581,7 @@ func (s *muxerServer) reset() {
 	}
 
 	s.segments = make([]muxerSegment)
-	s.segmentsByName = make(map[string]muxerSegment),
+	s.segmentsByName = make(map[string]muxerSegment)
 	s.partsByName = make(map[string]*muxerPart)
 
 	if s.init != nil {

--- a/muxer_server.go
+++ b/muxer_server.go
@@ -580,7 +580,7 @@ func (s *muxerServer) reset() {
 		segment.close()
 	}
 
-	s.segments = make([]muxerSegment)
+	s.segments = []muxerSegment{}
 	s.segmentsByName = make(map[string]muxerSegment)
 	s.partsByName = make(map[string]*muxerPart)
 

--- a/muxer_server.go
+++ b/muxer_server.go
@@ -567,28 +567,6 @@ func (s *muxerServer) close() {
 	}
 }
 
-func (s *muxerServer) reset() {
-	func() {
-		s.mutex.Lock()
-		defer s.mutex.Unlock()
-		s.closed = true
-	}()
-
-	s.cond.Broadcast()
-
-	for _, segment := range s.segments {
-		segment.close()
-	}
-
-	s.segments = []muxerSegment{}
-	s.segmentsByName = make(map[string]muxerSegment)
-	s.partsByName = make(map[string]*muxerPart)
-
-	if s.init != nil {
-		s.init.Remove()
-	}
-}
-
 func (s *muxerServer) hasContent() bool {
 	if s.variant == MuxerVariantFMP4 {
 		return len(s.segments) >= 2


### PR DESCRIPTION
## Changes

- [x] Muxer server no longer closes on `Reset()` since it was deleting segment files we intended to keep

## Notes

The issue was most noticeable after a reboot since the main app will start processing at the earliest playlist and the earliest segment. If we triggered a `Reset()` during this timeframe, any segments that had been created after bootup will be added to the playlist, but then get removed due to `server.close()` being called, resulting in "missing" segments.